### PR TITLE
fix: guard unresolved media_content_id in async_play_media

### DIFF
--- a/custom_components/ha_ncloud_music/media_player.py
+++ b/custom_components/ha_ncloud_music/media_player.py
@@ -326,6 +326,7 @@ class CloudMusicMediaPlayer(MediaPlayerEntity):
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         self._manual_stop_requested = False
+        media_content_id = None
 
         self._attr_state = STATE_PAUSED
         # 重置进度计时
@@ -376,6 +377,12 @@ class CloudMusicMediaPlayer(MediaPlayerEntity):
                     media_content_id = self._playlist_active[self._play_index].url
                 else:
                     media_content_id = self.playlist[self.playindex].url
+
+        if not media_content_id:
+            _LOGGER.error("播放失败：无法解析 media_content_id (media_id=%s, result=%s)", media_id, result)
+            self._attr_state = STATE_IDLE
+            self.async_write_ha_state()
+            return
 
         self._attr_media_content_id = media_content_id
         await self.async_call('play_media', {


### PR DESCRIPTION
### Motivation

- Prevent a crash or invalid playback call when `async_play_media` fails to resolve a usable `media_content_id` due to certain branches returning `None` or unexpected values.
- Avoid calling the underlying player with an unset or falsy `media_content_id`, which can lead to runtime errors or undefined behavior.

### Description

- Initialize `media_content_id` at the start of `async_play_media` by adding `media_content_id = None` to avoid an unbound variable scenario.
- Keep the previous resolution logic but add a defensive check `if not media_content_id:` that logs the failure, sets entity state to `STATE_IDLE`, calls `async_write_ha_state()`, and returns early instead of invoking `play_media` with invalid data.
- Changes applied in `custom_components/ha_ncloud_music/media_player.py` within the `CloudMusicMediaPlayer.async_play_media` flow.

### Testing

- Ran `python -m compileall -q custom_components/ha_ncloud_music/media_player.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47ee3ac1c8328a66f437e9468597f)